### PR TITLE
Strip trailing zeros after decimal point on toString

### DIFF
--- a/src/Decimal.elm
+++ b/src/Decimal.elm
@@ -179,6 +179,9 @@ fromString str =
             Nothing
 
 
+string_trailing_zeros : String -> String 
+string_trailing_zeros str = String.foldr (\c s -> if c == '0' && (String.length s == 0) then "" else (String.cons c s)) "" str
+
 insert_decimal_period : Int -> String -> String
 insert_decimal_period pos s =
     let
@@ -196,7 +199,7 @@ insert_decimal_period pos s =
             String.dropRight pos padded_s
 
         after =
-            String.right pos padded_s
+           string_trailing_zeros <| String.right pos padded_s
     in
     before ++ "." ++ after
 

--- a/src/Decimal.elm
+++ b/src/Decimal.elm
@@ -179,8 +179,8 @@ fromString str =
             Nothing
 
 
-string_trailing_zeros : String -> String
-string_trailing_zeros str =
+strip_trailing_zeros : String -> String
+strip_trailing_zeros str =
     String.foldr
         (\c s ->
             if c == '0' && (String.length s == 0) then
@@ -210,9 +210,14 @@ insert_decimal_period pos s =
             String.dropRight pos padded_s
 
         after =
-            string_trailing_zeros <| String.right pos padded_s
+            strip_trailing_zeros <| String.right pos padded_s
     in
-    before ++ "." ++ after
+    case String.length after == 0 of
+        True ->
+            before
+
+        False ->
+            before ++ "." ++ after
 
 
 {-| Converts a Decimal to a String

--- a/src/Decimal.elm
+++ b/src/Decimal.elm
@@ -179,8 +179,19 @@ fromString str =
             Nothing
 
 
-string_trailing_zeros : String -> String 
-string_trailing_zeros str = String.foldr (\c s -> if c == '0' && (String.length s == 0) then "" else (String.cons c s)) "" str
+string_trailing_zeros : String -> String
+string_trailing_zeros str =
+    String.foldr
+        (\c s ->
+            if c == '0' && (String.length s == 0) then
+                ""
+
+            else
+                String.cons c s
+        )
+        ""
+        str
+
 
 insert_decimal_period : Int -> String -> String
 insert_decimal_period pos s =
@@ -199,7 +210,7 @@ insert_decimal_period pos s =
             String.dropRight pos padded_s
 
         after =
-           string_trailing_zeros <| String.right pos padded_s
+            string_trailing_zeros <| String.right pos padded_s
     in
     before ++ "." ++ after
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -116,6 +116,9 @@ toStringTests =
         , test "decimal" <|
             \_ ->
                 Expect.equal "-1234.5678" (D.toString <| D.fromIntWithExponent -12345678 -4)
+        , test "zeros" <|
+            \_ ->
+                Expect.equal "0.123" (D.toString <| Maybe.withDefault (D.fromInt -1) <| D.fromString "0.123000")
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -119,6 +119,9 @@ toStringTests =
         , test "zeros" <|
             \_ ->
                 Expect.equal "0.123" (D.toString <| Maybe.withDefault (D.fromInt -1) <| D.fromString "0.123000")
+        , test "integer" <|
+            \_ ->
+                Expect.equal "1" (D.toString <| Maybe.withDefault (D.fromInt -1) <| D.fromString "1.0")
         ]
 
 


### PR DESCRIPTION
Partially fixes #1 

